### PR TITLE
Update Arxignis formula to version 0.1.1, updating download URLs and …

### DIFF
--- a/Formula/arxignis.rb
+++ b/Formula/arxignis.rb
@@ -4,31 +4,31 @@
 class Arxignis < Formula
   desc "Headless AppSec Security platform"
   homepage "https://arxignis.com"
-  version "0.0.2"
+  version "0.1.1"
   license "Apache-2.0"
-  url "https://github.com/arxignis/cli/releases/download/v0.0.2/ax.darwin-arm64.tar.gz"
-  sha256 "d395aa4fbb28f7ad79a889e8447bb6bde36c499879220d75be67a1adb2e1739e"
+  url "https://github.com/arxignis/cli/releases/download/v0.1.1/ax.darwin-arm64.tar.gz"
+  sha256 "7a7681aa9e96a02952fc42229332e228ab1732bb83bfd578ee21e4541e81fbbd"
   version_scheme 1
 
   on_macos do
     on_arm do
-      url "https://github.com/arxignis/cli/releases/download/v0.0.2/ax.darwin-arm64.tar.gz"
-      sha256 "d395aa4fbb28f7ad79a889e8447bb6bde36c499879220d75be67a1adb2e1739e"
+      url "https://github.com/arxignis/cli/releases/download/v0.1.1/ax.darwin-arm64.tar.gz"
+      sha256 "7a7681aa9e96a02952fc42229332e228ab1732bb83bfd578ee21e4541e81fbbd"
     end
     on_intel do
-      url "https://github.com/arxignis/cli/releases/download/v0.0.2/ax.darwin-amd64.tar.gz"
-      sha256 "30ea5d214b14c05ab7bef1b923a671c7d6d7479c88df1f55f06ee625c72015aa"
+      url "https://github.com/arxignis/cli/releases/download/v0.1.1/ax.darwin-amd64.tar.gz"
+      sha256 "988b49c39aaaf538011390aff35263839cd4c1d13fedad309c20b5bfcb808000"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/arxignis/cli/releases/download/v0.0.2/ax.linux-amd64.tar.gz"
-      sha256 "5c53f14dca5403587aa26c1c563523183a164906a4cf7774d3ba87123ae1c8ce"
+      url "https://github.com/arxignis/cli/releases/download/v0.1.1/ax.linux-amd64.tar.gz"
+      sha256 "ca22ae2b78acfd0d02d19919cecfd1efa8e3c7b26048573520f5a9d43af11dc9"
     end
     on_arm do
-      url "https://github.com/arxignis/cli/releases/download/v0.0.2/ax.linux-arm64.tar.gz"
-      sha256 "dc6d605a102f9dc3e480adfeb525cce708f389b9cff527e5bef0c582b16c9a7c"
+      url "https://github.com/arxignis/cli/releases/download/v0.1.1/ax.linux-arm64.tar.gz"
+      sha256 "844e740d632255532a8b3cfbe6d25fddf1e8f82edbf298c6d6203765bc4717ba"
     end
   end
 


### PR DESCRIPTION
…SHA256 checksums for macOS and Linux platforms.